### PR TITLE
Fix wrong Content-Type for responses

### DIFF
--- a/lib/auth.strategies/oauth/oauth.js
+++ b/lib/auth.strategies/oauth/oauth.js
@@ -92,7 +92,7 @@ module.exports= function(options) {
           res.end(error.message);
         }
         else {
-          res.writeHead(200, {'Content-Type': 'text/plain'})
+          res.writeHead(200, {'Content-Type': 'application/x-www-form-urlencoded'})
           res.end(["oauth_token=" + result["token"], "oauth_token_secret=" + result["token_secret"], "oauth_callback_confirmed=" + result["oauth_callback_confirmed"]].join("&"));
         }
       });
@@ -105,7 +105,7 @@ module.exports= function(options) {
           res.end(error.message);
         }
         else {
-          res.writeHead(200, {'Content-Type': 'text/plain'})
+          res.writeHead(200, {'Content-Type': 'application/x-www-form-urlencoded'})
           res.end(["oauth_token=" + result["access_token"], "oauth_token_secret=" + result["token_secret"]].join("&"));
         }
       });


### PR DESCRIPTION
RFC 5849 specify to use application/x-www-form-urlencoded as Content-Type response.

This fixes pump-io/pump.io#822 issue.